### PR TITLE
Fix rotation issue caused by zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This application is to capture large numbers of overlapping images from multiple viewpoints around an object for photogrammetric 3D reconstruction.
 To install prject dependencies, please run the code below in command:
 
+```
 $pip install -r requirements.txt
+```
 
 To start the project, please run main.py.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Computer-Operated Photogrammetric Imaging System (COPIS)
 
 This application is to capture large numbers of overlapping images from multiple viewpoints around an object for photogrammetric 3D reconstruction.
-To install prject dependencies, please run the code below in command:
+To install project dependencies, please run the code below in command:
 
 ```
 $pip install -r requirements.txt

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -107,6 +107,7 @@ class Canvas(CanvasBase):
 
         glTranslatef(0.0, 0.0, -1.5)
         glRotatef(15, 1.0, 0.0, 0.0)
+        glRotatef((self.z - self.lastz) * zScale, 1.0, 0.0, 0.0)
         glRotatef((self.x - self.lastx) * xScale, 0.0, 1.0, 0.0)
 
         self.InitGrid()

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -26,7 +26,7 @@ class CanvasBase(glcanvas.GLCanvas):
         self.Bind(wx.EVT_LEFT_DOWN, self.OnMouseDown)
         self.Bind(wx.EVT_LEFT_UP, self.OnMouseUp)
         self.Bind(wx.EVT_MOTION, self.OnMouseMotion)
-        self.Bind(wx.EVT_MOUSEWHEEL, self.OnMouseWheel)
+        # self.Bind(wx.EVT_MOUSEWHEEL, self.OnMouseWheel)
 
     def OnEraseBackground(self, event):
         pass # Do nothing, to avoid flashing on MSW.
@@ -38,7 +38,8 @@ class CanvasBase(glcanvas.GLCanvas):
     def DoSetViewport(self):
         size = self.size = self.GetClientSize()
         self.SetCurrent(self.context)
-        glViewport(0, 0, size.width, size.height)
+        min_size = min(size.width, size.height)
+        glViewport(0, 0, min_size, min_size)
         
     def OnPaint(self, event):
         self.SetCurrent(self.context)

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -38,6 +38,8 @@ class CanvasBase(glcanvas.GLCanvas):
     def DoSetViewport(self):
         size = self.size = self.GetClientSize()
         self.SetCurrent(self.context)
+
+        # set viewport dimensions to square (may change later)
         min_size = min(size.width, size.height)
         glViewport(0, 0, min_size, min_size)
         

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -13,7 +13,6 @@ class CanvasBase(glcanvas.GLCanvas):
         
         self.viewPoint = (0.0, 0.0, 0.0)
         self.zoom = 1
-        self.lastZoom = 1
         self.nearClip = 3.0
         self.farClip = 7.0
 
@@ -70,7 +69,6 @@ class CanvasBase(glcanvas.GLCanvas):
 
     def OnMouseWheel(self, event):
         wheelRotation = event.GetWheelRotation()
-        self.lastZoom = self.zoom
 
         if wheelRotation != 0:
             if wheelRotation > 0:

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -102,7 +102,7 @@ class Canvas(CanvasBase):
         # set viewing projection
         self.setProjectionMatrix()
 
-        # set camera
+        # initialize view
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()
         gluLookAt(0.0, 0.0, 5.0,
@@ -115,6 +115,8 @@ class Canvas(CanvasBase):
 
         self.setProjectionMatrix()
 
+        # there seems to be a difference between the commented chunk
+        # and the one below, but I'm not sure why they're different
         # w = max(self.w, 1.0)
         # h = max(self.h, 1.0)
         # xScale = 180.0 / w
@@ -171,8 +173,8 @@ class Canvas(CanvasBase):
         if self.w / self.h < 1:
             self.zoom *= self.w / self.h
 
-        # gluPerspective(np.arctan(np.tan(50.0 * 3.14159 / 360.0) / self.zoom) * 360.0 / 3.14159, self.w / self.h, self.nearClip, self.farClip)
-        glFrustum(-0.5 / self.zoom, 0.5 / self.zoom, -0.5 / self.zoom, 0.5 / self.zoom, self.nearClip, self.farClip)
+        gluPerspective(np.arctan(np.tan(50.0 * 3.14159 / 360.0) / self.zoom) * 360.0 / 3.14159, self.w / self.h, self.nearClip, self.farClip)
+        # glFrustum(-0.5 / self.zoom, 0.5 / self.zoom, -0.5 / self.zoom, 0.5 / self.zoom, self.nearClip, self.farClip)
 
         # set to position viewer
         glMatrixMode(GL_MODELVIEW)


### PR DESCRIPTION
Moved some parts of `setProjectionMatrix` to `InitGL`, as they do not need to be called on `onDraw`. Also added a line in `OnMouseUp` to remove residual mouse movement. Changed viewport dimension resizing to a square from the minimum of width/height to temporarily fix weird window scaling - ignore the `aspect` variable, I'll try to implement some fancy gluPerspective stuff based on aspect ratio.