### PR TITLE
Add arcball controls

### DIFF
--- a/components/arcball.py
+++ b/components/arcball.py
@@ -38,7 +38,7 @@ def cross(a, b):
 
 
 def axis_to_quat(axis, angle):
-    """Compute quaternion from rotation axis and angle."""
+    """Compute the quaternion given rotation axis and angle."""
     axis_len = math.sqrt(sum(x*x for x in axis))
     q = [x*(1 / axis_len) for x in axis]
     q = [x*math.sin(angle / 2.0) for x in q]

--- a/components/arcball.py
+++ b/components/arcball.py
@@ -4,7 +4,7 @@ TODO: Give attribution to Printrun
 """
 
 import math
-from OpenGL.GL import GLdouble
+from OpenGL.GL import GLfloat
 
 
 def arcball(p1x, p1y, p2x, p2y, r):
@@ -50,7 +50,7 @@ def quat_to_mat(q):
     """Convert the quaternion into a rotation matrix.
     x: q[0], y: q[1], z: q[2], w: q[3]
     """
-    m = (GLdouble*16)()
+    m = (GLfloat*16)()
     m[0] = 1.0 - 2.0*q[1]*q[1] - 2.0*q[2]*q[2]
     m[1] = 2.0*q[0]*q[1] - 2.0*q[2]*q[3]
     m[2] = 2.0*q[2]*q[0] + 2.0*q[1]*q[3]

--- a/components/arcball.py
+++ b/components/arcball.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Helper math functions to implement arcball rotation."""
+
+import math
+
+from OpenGL.GL import *
+from OpenGL.GLU import *
+
+
+def trackball(p1x, p1y, p2x, p2y, r):
+    if p1x == p2x and p1y == p2y:
+        return [0.0, 0.0, 0.0, 1.0]
+
+    v1 = [p1x, p1y, sphere_coords(p1x, p1y, r)]
+    v2 = [p2x, p2y, sphere_coords(p2x, p2y, r)]
+    # rot_axis = cross(v2, v1)
+    rot_axis = cross(v1, v2)
+
+    d = map(lambda x, y: x - y, v1, v2)
+    t = math.sqrt(sum(x*x for x in d)) / (2.0*r)
+
+    if t > 1.0:
+        t = 1.0
+    if t < -1.0:
+        t = -1.0
+    phi = 2.0 * math.asin(t)
+    # phi = math.acos(t)
+
+    return axis_to_quat(rot_axis, phi)
+
+
+def cross(v1, v2):
+    """Find the cross product between two vectors."""
+    return [v1[1]*v2[2] - v1[2]*v2[1],
+            v1[2]*v2[0] - v1[0]*v2[2],
+            v1[0]*v2[1] - v1[1]*v2[0]]
+
+
+def axis_to_quat(a, phi):
+    lena = math.sqrt(sum(x*x for x in a))
+    q = [x*(1 / lena) for x in a]
+    q = [x*math.sin(phi / 2.0) for x in q]
+    q.append(math.cos(phi / 2.0))
+    return q
+
+
+def quat_to_rotmatrix(q):
+    """Convert from a quaternion to a rotation matrix.
+    x: q[0], y: q[1], z: q[2], w: q[3]
+    """
+    m = (GLdouble*16)()
+    m[0] = 1.0 - 2.0*q[1]*q[1] - 2.0*q[2]*q[2]
+    m[1] = 2.0*q[0]*q[1] - 2.0*q[2]*q[3]
+    m[2] = 2.0*q[2]*q[0] + 2.0*q[1]*q[3]
+    m[3] = 0.0
+
+    m[4] = 2.0*q[0]*q[1] + 2.0*q[2]*q[3]
+    m[5] = 1.0 - 2.0*q[2]*q[2] - 2.0*q[0]*q[0]
+    m[6] = 2.0*q[1]*q[2] - 2.0*q[0]*q[3]
+    m[7] = 0.0
+
+    m[8] = 2.0*q[2]*q[0] - 2.0*q[1]*q[3]
+    m[9] = 2.0*q[1]*q[2] + 2.0*q[0]*q[3]
+    m[10] = 1.0 - 2.0*q[1]*q[1] - 2.0*q[0]*q[0]
+    m[11] = 0.0
+
+    m[12] = 0.0
+    m[13] = 0.0
+    m[14] = 0.0
+    m[15] = 1.0
+    return m
+
+
+def sphere_coords(x, y, r):
+    """Find the intersection from screen coords to the arcball sphere."""
+    d2 = x*x + y*y
+    r2 = r * r
+    if (math.sqrt(d2) <= r * 0.70710678118654752440):
+        return math.sqrt(r2 - d2)
+    else:
+        return r2 * 0.5 / math.sqrt(d2)
+
+
+def mul_quat(q1, rq):
+    """Multiply two quaternions."""
+    return [q1[3]*rq[0] + q1[0]*rq[3] + q1[1]*rq[2] - q1[2]*rq[1],  # 1
+            q1[3]*rq[1] + q1[1]*rq[3] + q1[2]*rq[0] - q1[0]*rq[2],  # i
+            q1[3]*rq[2] + q1[2]*rq[3] + q1[0]*rq[1] - q1[1]*rq[0],  # j
+            q1[3]*rq[3] - q1[0]*rq[0] - q1[1]*rq[1] - q1[2]*rq[2]]  # k

--- a/components/camview.py
+++ b/components/camview.py
@@ -73,20 +73,28 @@ class Canvas(CanvasBase):
 
     def handle_wheel(self, event):
         """(Currently unused) Reacts to mouse wheel changes."""
-        return
+        # return
 
         delta = event.GetWheelRotation()
+        print(delta)
         factor = 1.05
+        conditionalaspect
+
         x, y = event.GetPosition()
+        print(x,y)
         x, y, _ = self.mouse_to_3d(x, y, local_transform = True)
+        print(x,y,_)
+        
+        # return
         if delta > 0:
-            self.zoom(factor, (x, y))
+            self.zooom(factor, (x, y))
         else:
-            self.zoom(1 / factor, (x, y))
+            self.zooom(1 / factor, (x, y))
 
     def wheel(self, event):
         """React to the scroll wheel event."""
         self.onMouseWheel(event)
+        # self.handle_wheel(event)
         wx.CallAfter(self.Refresh)
 
     def double_click(self, event):
@@ -109,7 +117,7 @@ class Canvas(CanvasBase):
 
         # draw sphere
         glColor3ub(0, 0, 128)
-        gluSphere(self.quadratic, 0.2, 32, 32)
+        gluSphere(self.quadratic, 0.25, 32, 32)
 
     def draw_grid(self):
         """Draw coordinate grid."""

--- a/components/camview.py
+++ b/components/camview.py
@@ -98,7 +98,7 @@ class Canvas(CanvasBase):
         glLoadIdentity()
         gluLookAt(0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         # multiply modelview matrix according to rotation quat
-        glMultMatrixd(quat_to_mat(self.basequat))
+        glMultMatrixf(quat_to_mat(self.basequat))
 
         for cam in self.camera_objects:
             cam.onDraw()

--- a/components/camview.py
+++ b/components/camview.py
@@ -64,16 +64,11 @@ class Canvas(CanvasBase):
 
     def handle_wheel(self, event):
         """(Currently unused) Reacts to mouse wheel changes."""
-        # return
-
         delta = event.GetWheelRotation()
-        print(delta)
 
         factor = 1.05
         x, y = event.GetPosition()
-        print(x, y)
         x, y, _ = self.mouse_to_3d(x, y, local_transform=True)
-        print(x, y, _)
 
         if delta > 0:
             self.zoom_test(factor, (x, y))

--- a/components/camview.py
+++ b/components/camview.py
@@ -76,9 +76,9 @@ class Canvas(CanvasBase):
         print(x, y, _)
 
         if delta > 0:
-            self.zooom(factor, (x, y))
+            self.zoom_test(factor, (x, y))
         else:
-            self.zooom(1 / factor, (x, y))
+            self.zoom_test(1 / factor, (x, y))
 
     def wheel(self, event):
         """React to the scroll wheel event."""
@@ -94,10 +94,10 @@ class Canvas(CanvasBase):
         """Called in OnDraw after the buffer has been cleared."""
         self.create_objects()
 
-        # glTranslatef(0, 0, -self.dist)
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()
         gluLookAt(0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+        # multiply modelview matrix according to rotation quat
         glMultMatrixd(quat_to_mat(self.basequat))
 
         for cam in self.camera_objects:

--- a/components/camview.py
+++ b/components/camview.py
@@ -59,10 +59,7 @@ class Canvas(CanvasBase):
             self.handle_rotation(event)
         elif event.Dragging() and event.RightIsDown():
             self.handle_translation(event)
-        elif event.ButtonUp(wx.MOUSE_BTN_LEFT):
-            if self.initpos is not None:
-                self.initpos = None
-        elif event.ButtonUp(wx.MOUSE_BTN_RIGHT):
+        elif event.ButtonUp():
             if self.initpos is not None:
                 self.initpos = None
         else:
@@ -73,28 +70,20 @@ class Canvas(CanvasBase):
 
     def handle_wheel(self, event):
         """(Currently unused) Reacts to mouse wheel changes."""
-        # return
+        return
 
         delta = event.GetWheelRotation()
-        print(delta)
         factor = 1.05
-        conditionalaspect
-
         x, y = event.GetPosition()
-        print(x,y)
         x, y, _ = self.mouse_to_3d(x, y, local_transform = True)
-        print(x,y,_)
-        
-        # return
         if delta > 0:
-            self.zooom(factor, (x, y))
+            self.zoom(factor, (x, y))
         else:
-            self.zooom(1 / factor, (x, y))
+            self.zoom(1 / factor, (x, y))
 
     def wheel(self, event):
         """React to the scroll wheel event."""
         self.onMouseWheel(event)
-        # self.handle_wheel(event)
         wx.CallAfter(self.Refresh)
 
     def double_click(self, event):
@@ -117,7 +106,7 @@ class Canvas(CanvasBase):
 
         # draw sphere
         glColor3ub(0, 0, 128)
-        gluSphere(self.quadratic, 0.25, 32, 32)
+        gluSphere(self.quadratic, 0.2, 32, 32)
 
     def draw_grid(self):
         """Draw coordinate grid."""

--- a/components/camview.py
+++ b/components/camview.py
@@ -5,25 +5,26 @@ import numpy as np
 from enums import Axis
 
 import wx
-from wx import glcanvas
-
 from OpenGL.GL import *
 from OpenGL.GLU import *
 
 from .canvas import CanvasBase
-from .arcball import quat_to_rotmatrix
+from .arcball import quat_to_mat
 
 
 class Canvas(CanvasBase):
+    arcball_control = True
+
     def __init__(self, parent, *args, **kwargs):
         super(Canvas, self).__init__(parent)
         self.parent = parent
-        self.initpos = None
+
         self.mousepos = (0, 0)
         self.dist = 1
         self.basequat = [0, 0, 0, 1]
         self.scale = 1.0
         self.camera_objects = []
+        self.initpos = None
 
         self.Bind(wx.EVT_MOUSE_EVENTS, self.move)
         self.Bind(wx.EVT_MOUSEWHEEL, self.wheel)
@@ -49,7 +50,7 @@ class Canvas(CanvasBase):
         """
         self.mousepos = event.GetPosition()
         if event.Dragging() and event.LeftIsDown():
-            self.handle_rotation(event)
+            self.handle_rotation(event, arcball=self.arcball_control)
         elif event.Dragging() and event.RightIsDown():
             self.handle_translation(event)
         elif event.ButtonUp() or event.Leaving():
@@ -71,7 +72,7 @@ class Canvas(CanvasBase):
         factor = 1.05
         x, y = event.GetPosition()
         print(x, y)
-        x, y, _ = self.mouse_to_3d(x, y, local_transform = True)
+        x, y, _ = self.mouse_to_3d(x, y, local_transform=True)
         print(x, y, _)
 
         if delta > 0:
@@ -87,7 +88,7 @@ class Canvas(CanvasBase):
 
     def double_click(self, event):
         """React to the double click event."""
-        pass
+        return
 
     def draw_objects(self):
         """Called in OnDraw after the buffer has been cleared."""
@@ -97,7 +98,7 @@ class Canvas(CanvasBase):
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()
         gluLookAt(0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
-        glMultMatrixd(quat_to_rotmatrix(self.basequat))
+        glMultMatrixd(quat_to_mat(self.basequat))
 
         for cam in self.camera_objects:
             cam.onDraw()

--- a/components/camview.py
+++ b/components/camview.py
@@ -50,7 +50,7 @@ class Canvas(CanvasBase):
         """
         self.mousepos = event.GetPosition()
         if event.Dragging() and event.LeftIsDown():
-            self.handle_rotation(event, arcball=self.arcball_control)
+            self.handle_rotation(event, use_arcball=self.arcball_control)
         elif event.Dragging() and event.RightIsDown():
             self.handle_translation(event)
         elif event.ButtonUp() or event.Leaving():

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -243,8 +243,8 @@ class CanvasBase(glcanvas.GLCanvas):
 
     def handle_rotation(self, event, use_arcball=True):
         """Update basequat based on mouse position.
-        arcball = True:     Use arcball_rotation to rotate canvas.
-        arcball = False:    Use orbit_rotation to rotate canvas.
+        use_arcball = True:     Use arcball_rotation to rotate canvas.
+        use_arcball = False:    Use orbit_rotation to rotate canvas.
         """
         if self.initpos is None:
             self.initpos = event.GetPosition()

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -124,18 +124,17 @@ class CanvasBase(glcanvas.GLCanvas):
 
     def draw_objects(self):
         """Called in OnDraw after the buffer has been cleared."""
-        pass
+        return
 
     def create_objects(self):
         """Create OpenGL objects when window is initialized."""
-        pass
+        return
 
     def onMouseWheel(self, event):
         """Process mouse wheel event. Adjusts zoom accordingly
         and takes into consideration the zoom boundaries.
         """
         delta = event.GetWheelRotation()
-        print(delta)
 
         if delta != 0:
             if delta > 0:
@@ -196,11 +195,11 @@ class CanvasBase(glcanvas.GLCanvas):
     def mouse_to_plane(self, x, y, plane_normal, plane_offset, local_transform=False):
         # Ray/plane intersection
         ray_near, ray_far = self.mouse_to_ray(x, y, local_transform)
-        ray_near = numpy.array(ray_near)
-        ray_far = numpy.array(ray_far)
+        ray_near = np.array(ray_near)
+        ray_far = np.array(ray_far)
         ray_dir = ray_far - ray_near
         ray_dir = ray_dir / numpy.linalg.norm(ray_dir)
-        plane_normal = numpy.array(plane_normal)
+        plane_normal = np.array(plane_normal)
         q = ray_dir.dot(plane_normal)
         if q == 0:
             return None

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -209,7 +209,7 @@ class CanvasBase(glcanvas.GLCanvas):
             return None
         return ray_near + t * ray_dir
 
-    def zooom(self, factor, to = None):
+    def zoom_test(self, factor, to = None):
         glMatrixMode(GL_MODELVIEW)
         if to:
             delta_x = to[0]

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -171,7 +171,7 @@ class CanvasBase(glcanvas.GLCanvas):
         glGetIntegerv(GL_VIEWPORT, viewport)
         glGetDoublev(GL_PROJECTION_MATRIX, pmat)
         glGetDoublev(GL_MODELVIEW_MATRIX, mvmat)
-        gluUnProject(x, y, z, mvmat, pmat, viewport)#, px, py, pz)
+        gluUnProject(x, y, z, mvmat, pmat, viewport, px, py, pz)
         return (px.value, py.value, pz.value)
 
     def mouse_to_ray(self, x, y, local_transform=False):
@@ -198,7 +198,7 @@ class CanvasBase(glcanvas.GLCanvas):
         ray_near = np.array(ray_near)
         ray_far = np.array(ray_far)
         ray_dir = ray_far - ray_near
-        ray_dir = ray_dir / numpy.linalg.norm(ray_dir)
+        ray_dir = ray_dir / np.linalg.norm(ray_dir)
         plane_normal = np.array(plane_normal)
         q = ray_dir.dot(plane_normal)
         if q == 0:
@@ -208,7 +208,7 @@ class CanvasBase(glcanvas.GLCanvas):
             return None
         return ray_near + t * ray_dir
 
-    def zoom_test(self, factor, to = None):
+    def zoom_test(self, factor, to=None):
         glMatrixMode(GL_MODELVIEW)
         if to:
             delta_x = to[0]

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -24,12 +24,14 @@ class CanvasBase(glcanvas.GLCanvas):
         super(CanvasBase, self).__init__(parent, -1)
         self.GLinitialized = False
         self.context = glcanvas.GLContext(self)
-
+        self.context_attrs = glcanvas.GLContextAttrs()
+        self.display_attrs = glcanvas.GLAttributes()
         self.width = None
         self.height = None
 
         self.viewpoint = (0.0, 0.0, 0.0)
         self.basequat = [0, 0, 0, 1]
+        self.zoom_factor = 1.0
         self.angle_z = 0
         self.angle_x = 0
         self.zoom = 1
@@ -131,6 +133,7 @@ class CanvasBase(glcanvas.GLCanvas):
         and takes into consideration the zoom boundaries.
         """
         wheelRotation = event.GetWheelRotation()
+        print(wheelRotation)
 
         if wheelRotation != 0:
             if wheelRotation > 0:
@@ -167,7 +170,7 @@ class CanvasBase(glcanvas.GLCanvas):
         glGetIntegerv(GL_VIEWPORT, viewport)
         glGetDoublev(GL_PROJECTION_MATRIX, pmat)
         glGetDoublev(GL_MODELVIEW_MATRIX, mvmat)
-        gluUnProject(x, y, z, mvmat, pmat, viewport, px, py, pz)
+        gluUnProject(x, y, z, mvmat, pmat, viewport)#, px, py, pz)
         return (px.value, py.value, pz.value)
 
     def mouse_to_ray(self, x, y, local_transform=False):
@@ -203,6 +206,18 @@ class CanvasBase(glcanvas.GLCanvas):
         if t < 0:
             return None
         return ray_near + t * ray_dir
+
+    def zooom(self, factor, to = None):
+        glMatrixMode(GL_MODELVIEW)
+        if to:
+            delta_x = to[0]
+            delta_y = to[1]
+            glTranslatef(delta_x, delta_y, 0)
+        glScalef(factor, factor, 1)
+        self.zoom_factor *= factor
+        if to:
+            glTranslatef(-delta_x, -delta_y, 0)
+        wx.CallAfter(self.Refresh)
 
     def orbit(self, p1x, p1y, p2x, p2y):
         pass

--- a/components/canvas.py
+++ b/components/canvas.py
@@ -241,7 +241,7 @@ class CanvasBase(glcanvas.GLCanvas):
         quat = arcball(p1x, p1y, p2x, p2y, 1)
         return mul_quat(self.basequat, quat)
 
-    def handle_rotation(self, event, arcball=True):
+    def handle_rotation(self, event, use_arcball=True):
         """Update basequat based on mouse position.
         arcball = True:     Use arcball_rotation to rotate canvas.
         arcball = False:    Use orbit_rotation to rotate canvas.
@@ -258,7 +258,7 @@ class CanvasBase(glcanvas.GLCanvas):
         cur_y = 1 - float(cur.y) * 2.0 / self.height
         
         with self.rot_lock:
-            if arcball:
+            if use_arcball:
                 self.basequat = self.arcball_rotation(last_x, last_y, cur_x, cur_y)
             else:
                 self.basequat = self.orbit_rotation(last_x, last_y, cur_x, cur_y)

--- a/panels/controllerPanel.py
+++ b/panels/controllerPanel.py
@@ -95,7 +95,7 @@ class ControllerPanel(wx.Panel):
 
         self.createVCamBtn = wx.Button(self, wx.ID_ANY, label = "Create 3D camera")
         self.createVCamBtn.Bind(wx.EVT_BUTTON, self.onCreateVirtualCam)
-        hboxTop.Add(self.createVCamBtn, flag = wx.ALIGN_RIGHT)
+        hboxTop.Add(self.createVCamBtn)
         vboxPositioning.Add(hboxTop, 0.5 , flag = wx.LEFT|wx.BOTTOM|wx.EXPAND, border = 15)
 
         hboxXyzbc = wx.BoxSizer()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ PyOpenGL==3.1.5
 pyserial==3.4
 serial==0.0.97
 six==1.14.0
-wxPython==4.0.7.post2
+wxPython==4.1.0


### PR DESCRIPTION
Add arcball controls, another way of rotating the visualizer panel. Video demo: [link](https://www.youtube.com/watch?v=P45gZCjQ7hc). More details on changes:
- `handle_rotation()` is now fully fleshed out, and you can choose between the new arcball controls or the previous axis orbit controls. Specify the `use_arcball` argument in `handle_rotation()` to select between the two rotation methods.
  - Added `orbit_rotation` and `arcball_rotation`, which processes mouse positions with either the old orbit controls or new arcball controls.
  - This all works by updating `basequat`, a quaternion representing the canvas rotation, in `draw_objects()`. `basequat` gets converted into a rotation matrix, and the canvas is rotated with `glMultMatrixf`.
- Added `arcball.py`, which contains helper functions to perform the vector and quaternion math used in arcball rotations.
  - Credit and an explanation of the math behind all this: [link1](https://en.wikibooks.org/wiki/OpenGL_Programming/Modern_OpenGL_Tutorial_Arcball), [link2](https://pixeladventuresweb.wordpress.com/2016/10/04/arcball-controller/), and [link3](https://github.com/kliment/Printrun/blob/master/printrun/gl/trackball.py)
- Moved event binders in `Canvas` to `__init__`, not sure why they were in `OnInitGL`
- Added docstrings!

