### PR TITLE
Improve import style with relative imports

### DIFF
--- a/copis/client.py
+++ b/copis/client.py
@@ -17,13 +17,12 @@
 
 """Main COPIS App (GUI)."""
 
-import logging
 import wx
 import wx.lib.inspection
 
-from copis.config import Config
-from copis.core import COPISCore
-from copis.gui.main_frame import MainWindow
+from .config import Config
+from .core import COPISCore
+from .gui.main_frame import MainWindow
 
 
 class COPISApp(wx.App):
@@ -47,18 +46,3 @@ class COPISApp(wx.App):
             size=(self.config.settings.app_window_width, self.config.settings.app_window_height)
         )
         self.mainwindow.Show()
-
-
-if __name__ == '__main__':
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
-
-    app = COPISApp()
-    try:
-        # wx.lib.inspection.InspectionTool().Show() # debug
-        app.MainLoop()
-    except KeyboardInterrupt:
-        print("hello")
-
-    app.core.terminate_edsdk()
-    del app

--- a/copis/config.py
+++ b/copis/config.py
@@ -17,9 +17,9 @@ import os
 
 from configparser import ConfigParser
 
-from enums import DebugEnv
-from store import Store
-from settings import Settings
+from .enums import DebugEnv
+from .store import Store
+from .settings import Settings
 
 
 class Config():

--- a/copis/console.py
+++ b/copis/console.py
@@ -25,7 +25,7 @@ TODO: The entire thing is a todo
 
 import cmd
 
-from copis.core import COPISCore
+from .core import COPISCore
 
 
 class COPISConsole(cmd.Cmd):

--- a/copis/core.py
+++ b/copis/core.py
@@ -22,8 +22,10 @@ if sys.version_info.major < 3:
     print("You need to run this on Python 3")
     sys.exit(-1)
 
+# pylint: disable=wrong-import-position
+from importlib import import_module
 import logging
-import math
+
 import os
 import platform
 import threading
@@ -36,10 +38,9 @@ from typing import List, Optional, Tuple
 import glm
 from pydispatch import dispatcher
 
-from copis.enums import Action, ActionType, Device, Proxy
-from copis.gl.glutils import get_circle
-from copis.helpers import Point3, Point5
-from copis.store import Store
+from .enums import Action, ActionType, Device, Proxy
+from .helpers import Point3, Point5
+from .store import Store
 
 
 def locked(f):
@@ -568,6 +569,7 @@ class COPISCore:
             self._edsdk.connect()
 
         except: # TODO: add better exception perhaps
+            print('fuck')
             self._edsdk_enabled = False
 
     def terminate_edsdk(self):

--- a/copis/enums.py
+++ b/copis/enums.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum, auto, unique
 from typing import Any, List, Optional, Tuple
 
-from copis.helpers import Point3, Point5
+from .helpers import Point3, Point5
 
 
 class ToolIds(Enum):

--- a/copis/gl/glcanvas.py
+++ b/copis/gl/glcanvas.py
@@ -30,9 +30,9 @@ import numpy as np
 import pywavefront
 import wx
 
-from copis.gl.actionvis import GLActionVis
-from copis.gl.chamber import GLChamber
-from copis.gl.viewcube import GLViewCube
+from .actionvis import GLActionVis
+from .chamber import GLChamber
+from .viewcube import GLViewCube
 from copis.helpers import find_path, timing
 from copis.mathutils import arcball
 

--- a/copis/gui/main_frame.py
+++ b/copis/gui/main_frame.py
@@ -20,18 +20,18 @@ from pathlib import Path
 
 import wx
 import wx.lib.agw.aui as aui
-from copis.gui.about import AboutDialog
-from copis.gui.panels.console import ConsolePanel
-from copis.gui.panels.controller import ControllerPanel
-from copis.gui.panels.evf import EvfPanel
-from copis.gui.panels.machine_toolbar import MachineToolbar
-from copis.gui.panels.pathgen_toolbar import PathgenToolbar
-from copis.gui.panels.properties import PropertiesPanel
-from copis.gui.panels.timeline import TimelinePanel
-from copis.gui.panels.visualizer import VisualizerPanel
-from copis.gui.pref_frame import PreferenceFrame
-from copis.gui.proxyconfig_frame import ProxyConfigFrame
-from copis.gui.wxutils import create_scaled_bitmap, set_dialog
+from .about import AboutDialog
+from .panels.console import ConsolePanel
+from .panels.controller import ControllerPanel
+from .panels.evf import EvfPanel
+from .panels.machine_toolbar import MachineToolbar
+from .panels.pathgen_toolbar import PathgenToolbar
+from .panels.properties import PropertiesPanel
+from .panels.timeline import TimelinePanel
+from .panels.visualizer import VisualizerPanel
+from .pref_frame import PreferenceFrame
+from .proxyconfig_frame import ProxyConfigFrame
+from .wxutils import create_scaled_bitmap, set_dialog
 from copis.store import Store
 
 from wx.lib.agw.aui.aui_constants import *

--- a/copis/gui/panels/controller.py
+++ b/copis/gui/panels/controller.py
@@ -21,11 +21,11 @@ serial connections are implemented.
 
 import wx
 import wx.lib.scrolledpanel as scrolled
+from pydispatch import dispatcher
 from copis.gui.wxutils import (
     EVT_FANCY_TEXT_UPDATED_EVENT, FancyTextCtrl,
     create_scaled_bitmap, simple_statictext)
-from pydispatch import dispatcher
-from helpers import Point5, pt_units, xyz_units
+from copis.helpers import Point5, pt_units, xyz_units
 
 
 class ControllerPanel(scrolled.ScrolledPanel):

--- a/copis/pathutils.py
+++ b/copis/pathutils.py
@@ -22,7 +22,7 @@ from typing import Tuple
 import numpy as np
 import glm
 
-from copis.mathutils import rotate_basis_to
+from .mathutils import rotate_basis_to
 
 
 def create_circle(p: glm.vec3,

--- a/copis/settings.py
+++ b/copis/settings.py
@@ -15,7 +15,7 @@
 
 from dataclasses import dataclass
 
-from enums import DebugEnv
+from .enums import DebugEnv
 
 @dataclass
 class Settings:

--- a/copis/store.py
+++ b/copis/store.py
@@ -23,7 +23,7 @@ from configparser import ConfigParser
 from pathlib import PurePath
 from typing import Optional
 
-from settings import Settings
+from .settings import Settings
 
 
 class Store():

--- a/copisclient.py
+++ b/copisclient.py
@@ -1,6 +1,34 @@
-import os, sys
+#!/usr/bin/env python3
 
-path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'copis')
-sys.path.insert(0, path)
+# This file is part of COPISClient.
+#
+# COPISClient is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# COPISClient is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with COPISClient.  If not, see <https://www.gnu.org/licenses/>.
 
-exec(open(os.path.join(path, 'client.py')).read())
+import logging
+
+from copis.client import COPISApp
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    app = COPISApp()
+    try:
+        app.MainLoop()
+    except KeyboardInterrupt:
+        logging.debug('KeyboardInterrupt')
+
+    app.core.terminate_edsdk()
+    del app


### PR DESCRIPTION
Use explicit relative imports to simplify importing. Move `__main__` from `copis/core.py` to `copisclient.py`.