### PR TITLE
Make Serial Rx & Tx Logging optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # User-specific files
 *.ini
+!ex/*.ini
 *.suo
 *.user
 *.userosscache

--- a/copis/classes/proxy_objects.py
+++ b/copis/classes/proxy_objects.py
@@ -86,10 +86,6 @@ class CylinderObject3D(Object3D):
         self.height: float = glm.distance(self.start, self.end)
         self.normal: vec3 = glm.normalize(self.end - self.start)
 
-        self.b1: vec3
-        self.b2: vec3
-        self.b1, self.b2 = orthonormal_basis_of(self.normal)
-
         # calculate rotation matrix for cylinder
         self.trans_matrix: mat4 = glm.orientation(vec3(0.0, 0.0, 1.0), self.normal)
 

--- a/copis/coms/serial_controller.py
+++ b/copis/coms/serial_controller.py
@@ -75,6 +75,7 @@ class SerialController():
 
     def __init__(self):
         self._sys_db = None
+        self._log_options = None
         self._ports = []
         self._active_port = None
         self._console = None
@@ -94,11 +95,12 @@ class SerialController():
 
         self.update_port_list()
 
-    def attach_sys_db(self, sys_db : SysDB) -> bool:
+    def attach_sys_db(self, sys_db : SysDB, log_options: dict=None) -> bool:
         """Mounts the system database if it is provided."""
         if sys_db.is_initialized:
             self._sys_db = sys_db
             self._db_attached = True
+            self._log_options = log_options
         else:
             self._db_attached = False
         return self._db_attached
@@ -181,7 +183,7 @@ class SerialController():
             data = data.rstrip("\r")
             data = f'{data}\r'.encode()
 
-            if self._db_attached:
+            if self._db_attached and self._log_options and self._log_options.get('log_tx'):
                 self._sys_db.serial_tx(data)
 
             active_port.connection.write(data)
@@ -236,8 +238,9 @@ class SerialController():
             p_bytes = port.connection.readline()
             resp = p_bytes.decode()
 
-            if self._db_attached:
+            if self._db_attached and self._log_options and self._log_options.get('log_rx'):
                 self._sys_db.serial_rx(p_bytes)
+
             if resp:
                 self._print_raw_msg(self._console, resp)
 

--- a/copis/config.py
+++ b/copis/config.py
@@ -44,6 +44,26 @@ class Config():
         self._application_settings = self._populate_application_settings()
         self._machine_settings = self._populate_machine_settings()
 
+        self._log_serial_tx = False
+        self._log_serial_rx = False
+        db_path = store.get_sys_db_path()
+
+        if db_path and self._config_parser.has_option('System', 'log_serial_tx'):
+            self._log_serial_tx = _get_bool(self._config_parser['System']['log_serial_tx'])
+
+        if db_path and self._config_parser.has_option('System', 'log_serial_rx'):
+            self._log_serial_rx = _get_bool(self._config_parser['System']['log_serial_rx'])
+
+    @property
+    def log_serial_tx(self) -> bool:
+        """Returns a flag indicating whether to log serial Tx, if a database is configured."""
+        return self._log_serial_tx
+
+    @property
+    def log_serial_rx(self) -> bool:
+        """Returns a flag indicating whether to log serial Rx, if a database is configured."""
+        return self._log_serial_rx
+
     @property
     def application_settings(self) -> ApplicationSettings:
         """Application configuration settings getter."""
@@ -112,7 +132,7 @@ class Config():
         debug_env = app['debug_env']
 
         if not any(e.value == debug_env for e in DebugEnv):
-            debug_env = self._DEFAULT_CONFIG[section]['debug_env']
+            debug_env = 'prod'
 
         app_settings = ApplicationSettings(DebugEnv(debug_env), window_min_size, window_state)
 

--- a/copis/core/__init__.py
+++ b/copis/core/__init__.py
@@ -88,7 +88,11 @@ class COPISCore:
 
         self.init_edsdk()
         self.init_serial()
-        self._serial.attach_sys_db(self.sys_db)
+        serial_log_opts = {
+            'log_tx': self.config.log_serial_tx,
+            'log_rx': self.config.log_serial_rx
+        }
+        self._serial.attach_sys_db(self.sys_db, serial_log_opts)
         self._edsdk.attach_sys_db(self.sys_db)
         # Attach serial.
         self._check_configs()

--- a/ex/ex.ini
+++ b/ex/ex.ini
@@ -18,4 +18,5 @@ default_proxy_path = proxies\handsome_dan.obj
 
 [System]
 db = db\copis.db
-
+log_serial_tx = false
+log_serial_rx = false


### PR DESCRIPTION
These options will be false by default; meaning that once deployed to an existing installation, serial Rx/Tx logging will be automatically turned off.